### PR TITLE
chore: add alternative jandapress deployment

### DIFF
--- a/CLOSING_REMARKS.md
+++ b/CLOSING_REMARKS.md
@@ -9,7 +9,15 @@ allows this services to operate.
 - [hentai2read](https://hentai2read.com)
 - [asmhentai](https://asmhentai.com)
 - [simply-hentai](https://simply-hentai.com)
+- [3hentai](http://3hentai.net)
 
 Major dependencies:
 - [express](https://github.com/expressjs/express)
 - [cheerio](https://cheerio.js.org/)
+- [keyv](https://github.com/jaredwray/keyv)
+
+# Alternative-links
+Just in case if https://janda.mod.land down, here some alternative deployment
+
+- https://janda.sinkaroid.org
+- https://janda.fly.dev


### PR DESCRIPTION
Just in case if https://janda.mod.land down here