### PR TITLE
fix: cache should be stored in a hour

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -10,5 +10,5 @@ RAILWAY=sinkaroid
 PORT=3000
 REDIS_URL=redis://default:somenicepassword@redis-666.c10.us-east-6-6.ec666.cloud.redislabs.com:1337
 
-# ttl for cache in a day
+# ttl for cache in a hour
 EXPIRE_CACHE=1

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Rename `.env.schema` to `.env` and fill the value with your own.
 ```bash
 PORT=3000 ## default port
 REDIS_URL=redis://default:somenicepassword@someredishost:1337 ## the database url
-EXPIRE_CACHE=1 ## should expired in a day
+EXPIRE_CACHE=1 ## a hour
 ```
 
 ### Docker

--- a/src/JandaPress.ts
+++ b/src/JandaPress.ts
@@ -6,7 +6,7 @@ dotenv.config();
 const keyv = new Keyv(process.env.REDIS_URL);
 
 keyv.on("error", err => console.log("Connection Error", err));
-const ttl = 1000 * 60 * 60 * 24 * Number(process.env.EXPIRE_CACHE);
+const ttl = 1000 * 60 * 60 * Number(process.env.EXPIRE_CACHE);
 
 class JandaPress {
   url: string;


### PR DESCRIPTION
CC: Redis Email Alert
```
Hello Okita Alter,

The total size of datasets under your plan has reached 81.66% of the memory limit
```
Free tier of redis only 30MB, the default configuration should follow this behaviour or it's mess