### PR TITLE
fix: make GET / resilient to geo service failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ To continue using Jandapress, please deploy and run your own self-hosted instanc
 - `/` : index page
 
 ### Nhentai
-The missing piece of nhentai.net - https://sinkaroid.github.io/jandapress/#api-nhentai
+The missing piece of nhentai - https://sinkaroid.github.io/jandapress/#GET/nhentai
 - `/nhentai` : nhentai api
   - **get**, takes parameters : `book`
   - **search**, takes parameters : `key`, `?page`, `?sort`
@@ -202,7 +202,7 @@ The missing piece of nhentai.net - https://sinkaroid.github.io/jandapress/#api-n
     - http://localhost:3000/nhentai/random
 
 ### Pururin
-The missing piece of pururin.to - https://sinkaroid.github.io/jandapress/#api-pururin
+The missing piece of pururin - https://sinkaroid.github.io/jandapress/#GET/pururin
 - `/pururin` : pururin api
   - **get**, takes parameters : `book`
   - **search**, takes parameters : `key`, `?page`
@@ -213,7 +213,7 @@ The missing piece of pururin.to - https://sinkaroid.github.io/jandapress/#api-pu
     - http://localhost:3000/pururin/random
 
 ### Hentaifox
-The missing piece of hentaifox.com - https://sinkaroid.github.io/jandapress/#api-hentaifox
+The missing piece of hentaifox - https://sinkaroid.github.io/jandapress/#GET/hentaifox
 - `/hentaifox`: hentaifox api
   - **get**, takes parameters : `book`
   - **search**, takes parameters : `key`, `?page`, `?sort`
@@ -227,7 +227,7 @@ The missing piece of hentaifox.com - https://sinkaroid.github.io/jandapress/#api
     - http://localhost:3000/hentaifox/random
 
 ### Asmhentai
-The missing piece of asmhentai.com - https://sinkaroid.github.io/jandapress/#api-asmhentai
+The missing piece of asmhentai - https://sinkaroid.github.io/jandapress/#GET/asmhentai
 - `/asmhentai`: asmhentai api
   - **get**, takes parameters : `book`
   - **search**, takes parameters : `key`, `?page`
@@ -241,7 +241,7 @@ The missing piece of asmhentai.com - https://sinkaroid.github.io/jandapress/#api
     - http://localhost:3000/asmhentai/random
 
 ### Hentai2read
-The missing piece of hentai2read.com - https://sinkaroid.github.io/jandapress/#api-hentai2read
+The missing piece of hentai2read - https://sinkaroid.github.io/jandapress/#GET/hentai2read
 - `/hentai2read`: hentai2read api
   - **get**, takes parameters : `book`
   - **search**, takes parameters : `key`
@@ -252,7 +252,7 @@ The missing piece of hentai2read.com - https://sinkaroid.github.io/jandapress/#a
     - http://localhost:3000/hentai2read/search?key=futanari
 
 ### Simply-hentai
-The missing piece of simply-hentai.com - https://sinkaroid.github.io/jandapress/#api-simply-hentai
+The missing piece of simply-hentai - https://sinkaroid.github.io/jandapress/#GET/simply-hentai
 - `/simply-hentai`: simply-hentai api
   - **get**, takes parameters : `book`
   - <u>sort parameters on search</u>
@@ -261,7 +261,7 @@ The missing piece of simply-hentai.com - https://sinkaroid.github.io/jandapress/
     - http://localhost:3000/simply-hentai/get?book=fate-grand-order/fgo-sanbunkatsuhou/all-pages
 
 ### 3hentai
-The missing piece of 3hentai.net - https://sinkaroid.github.io/jandapress/#api-3hentai
+The missing piece of 3hentai - https://sinkaroid.github.io/jandapress/#GET/3hentai
 - `/3hentai`: 3hentai api
   - **get**, takes parameters : `book`
   - **search**, takes parameters : `key`, `?page`, `?sort`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jandapress",
-  "version": "10.0.2-alpha",
+  "version": "10.0.3-alpha",
   "description": "RESTful and experimental API for the Doujinshi, Pressing the whole nhentai, pururin, hentaifox, and more.",
   "main": "build/src/index.js",
   "scripts": {

--- a/src/JandaPress.ts
+++ b/src/JandaPress.ts
@@ -1,6 +1,6 @@
 import Keyv from "keyv";
 import KeyvRedis from "@keyv/redis";
-import { nhentaiHeaders } from "./utils/modifier";
+import { defaultUserAgent, nhentaiHeaders } from "./utils/modifier";
 
 const keyv = process.env.REDIS_URL
   ? new Keyv({ store: new KeyvRedis(process.env.REDIS_URL) })
@@ -15,7 +15,7 @@ class JandaPress {
   useragent: string;
   constructor() {
     this.url = "";
-    this.useragent = process.env.USER_AGENT || "jandapress/10.0.1-alpha Bun/1.3.13";
+    this.useragent = process.env.USER_AGENT || defaultUserAgent();
   }
 
   /**
@@ -113,12 +113,26 @@ class JandaPress {
   }
 
   async getServer(): Promise<string> {
-    const raw = await fetch("https://ip-api.com/json");
-    if (!raw.ok) {
-      throw new Error(`Request failed with status ${raw.status}`);
+    try {
+      // ip-api free tier often rejects HTTPS requests with 403;
+      const raw = await fetch("https://ipwho.is/");
+      if (!raw.ok) {
+        return "Unknown";
+      }
+      const data = await raw.json() as {
+        success?: boolean;
+        country?: string;
+        region?: string;
+      };
+      if (data.success === false) {
+        return "Unknown";
+      }
+      const country = data.country ?? "Unknown";
+      const region = data.region ?? "Unknown";
+      return `${country}, ${region}`;
+    } catch {
+      return "Unknown";
     }
-    const data = await raw.json() as { country: string, regionName: string };
-    return `${data.country}, ${data.regionName}`;
     
   }
 }

--- a/src/JandaPress.ts
+++ b/src/JandaPress.ts
@@ -8,6 +8,17 @@ const keyv = process.env.REDIS_URL
   
 keyv.on("error", err => console.log("Connection Error", err));
 const ttl = 1000 * 60 * 60 * Number(process.env.EXPIRE_CACHE);
+const GEO_TIMEOUT_MS = 3000;
+
+let cachedLastLocation: string | null = null;
+let lastLocationTimestamp = 0;
+
+function cachedLocationOrUnknown(): string {
+  if (cachedLastLocation && lastLocationTimestamp > 0) {
+    return cachedLastLocation;
+  }
+  return "Unknown";
+}
 
 
 class JandaPress {
@@ -113,11 +124,16 @@ class JandaPress {
   }
 
   async getServer(): Promise<string> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), GEO_TIMEOUT_MS);
+
     try {
       // ip-api free tier often rejects HTTPS requests with 403;
-      const raw = await fetch("https://ipwho.is/");
+      const raw = await fetch("https://ipwho.is/", {
+        signal: controller.signal,
+      });
       if (!raw.ok) {
-        return "Unknown";
+        return cachedLocationOrUnknown();
       }
       const data = await raw.json() as {
         success?: boolean;
@@ -125,13 +141,25 @@ class JandaPress {
         region?: string;
       };
       if (data.success === false) {
-        return "Unknown";
+        return cachedLocationOrUnknown();
       }
-      const country = data.country ?? "Unknown";
-      const region = data.region ?? "Unknown";
-      return `${country}, ${region}`;
+      const country = data.country?.trim();
+      const region = data.region?.trim();
+      if (!country || !region) {
+        return cachedLocationOrUnknown();
+      }
+
+      const location = `${country}, ${region}`;
+      cachedLastLocation = location;
+      lastLocationTimestamp = Date.now();
+      return location;
     } catch {
-      return "Unknown";
+      return cachedLocationOrUnknown();
+    } finally {
+      clearTimeout(timeoutId);
+      if (!controller.signal.aborted) {
+        controller.abort();
+      }
     }
     
   }

--- a/src/lib/openapi-spec.ts
+++ b/src/lib/openapi-spec.ts
@@ -1,8 +1,10 @@
+import * as pkg from "../../package.json";
+
 export const openAPISpec = {
   openapi: "3.0.0",
   info: {
     title: "JandaPress API",
-    version: "10.0.2-alpha",
+    version: `${pkg.version}`,
     description: "RESTful API for nhentai, pururin, hentaifox, asmhentai, hentai2read, simply-hentai, and 3hentai.",
     contact: {
       name: "sinkaroid",

--- a/src/utils/modifier.ts
+++ b/src/utils/modifier.ts
@@ -1,6 +1,16 @@
 import { load } from "cheerio";
 import c from "./options";
 import { nhentaiRandomUrl } from "./nhentai";
+import * as pkg from "../../package.json";
+
+function runtimeBunVersion(): string {
+  const bunFromGlobal = (globalThis as { Bun?: { version?: string } }).Bun?.version;
+  return bunFromGlobal ?? process.versions.bun ?? "unknown";
+}
+
+export function defaultUserAgent(): string {
+  return `${pkg.name}/${pkg.version} Bun/${runtimeBunVersion()}`;
+}
 
 /**
  * Get Pururin info and replace
@@ -175,7 +185,7 @@ export function maybeError(success: boolean, message: string) {
  */
 export function nhentaiHeaders(): Record<string, string> {
   const key = process.env.NHENTAI_API_KEY?.trim();
-  const userAgent = process.env.USER_AGENT || "jandapress/10.0.1-alpha Bun/1.3.13";
+  const userAgent = process.env.USER_AGENT || defaultUserAgent();
   const maskedKey = key ? `${key.slice(0, 6)}...(${key.length})` : "none";
 
   console.log(`[nhentai] headers ready | apiKey=${maskedKey} | auth=${key ? "Bearer" : "none"} | ua=${userAgent}`);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Announced discontinuation of publicly hosted playground and APIs (March 11, 2026); users must self-host
  * Updated API documentation anchors/links across source endpoints

* **Chores**
  * Version bumped to 10.0.3-alpha
  * OpenAPI info now reflects package version automatically

* **Bug Fixes / Improvements**
  * More robust User-Agent handling with a safer default
  * Geo-location lookup is now resilient (timeout, caching, and no hard failure on errors)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->